### PR TITLE
Update CashOnDelivery.php

### DIFF
--- a/app/code/community/Phoenix/CashOnDelivery/Model/CashOnDelivery.php
+++ b/app/code/community/Phoenix/CashOnDelivery/Model/CashOnDelivery.php
@@ -164,16 +164,16 @@ class Phoenix_CashOnDelivery_Model_CashOnDelivery extends Mage_Payment_Model_Met
      * @return bool
      */
     public function isAvailable($quote = null)
-    {
-        if ($quote->isVirtual()) {
-            return false;
-        }
-
+    {        
         if (!parent::isAvailable($quote)) {
             return false;
         }
 
         if (!is_null($quote)) {
+            if ($quote->isVirtual()) {
+                return false;
+            }
+            
             if ($this->getConfigData('shippingallowspecific', $quote->getStoreId()) == 1) {
                 $country            = $quote->getShippingAddress()->getCountry();
                 $availableCountries = $this->getConfigData('shippingspecificcountry', $quote->getStoreId());


### PR DESCRIPTION
In row 168 it is better to include isVirtual() check within the conditional block, so the method isVirtual will be called only if $quote is not empty.